### PR TITLE
Add additional events and better event args

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebSocketTextClient
 
-Wrapper around System.Net.WebSockets.ClientWebSocket that provides event based interface to exchange text messages over Web Sockets in event based way and support cancellation.
+Wrapper around System.Net.WebSockets.ClientWebSocket that provides event based interface to exchange text messages over Web Sockets in event based way and support cancellation. Includes events for open/close, message received and error received.
 
 ## Target Platform: 
 .NET Standard 2.0
@@ -22,7 +22,7 @@ Wrapper around System.Net.WebSockets.ClientWebSocket that provides event based i
 using (var cts = new CancellationTokenSource())
 using (var client = new WebSocketTextClient(cts.Token))
 {
-    client.OnResponse = (sender, eventArgs) => Console.WriteLine(eventArgs.Message);
+    client.MessageReceived = (sender, eventArgs) => Console.WriteLine(eventArgs.Message);
 
     await client.ConnectAsync(new Uri("ws://example.com"));
     await client.SendAsync("ping");

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Wrapper around System.Net.WebSockets.ClientWebSocket that provides event based i
 using (var cts = new CancellationTokenSource())
 using (var client = new WebSocketTextClient(cts.Token))
 {
-    client.OnResponse = (text) => Console.WriteLine(text);
+    client.OnResponse = (sender, eventArgs) => Console.WriteLine(eventArgs.Message);
 
     await client.ConnectAsync(new Uri("ws://example.com"));
     await client.SendAsync("ping");

--- a/WebSocketTextClient/MessageReceivedEventArgs.cs
+++ b/WebSocketTextClient/MessageReceivedEventArgs.cs
@@ -1,0 +1,11 @@
+﻿namespace WebSockets
+{
+    using System;
+
+    /// <summary> Provides additional data for the <see cref="WebSocketTextClient.MessageReceived"/> event.</summary>
+    public sealed class MessageReceivedEventArgs : EventArgs
+    {
+        /// <summary>Gets or sets the message that was received.</summary>
+        public string Message { get; set; }
+    }
+}

--- a/WebSocketTextClient/SocketErrorEventArgs.cs
+++ b/WebSocketTextClient/SocketErrorEventArgs.cs
@@ -7,8 +7,5 @@
     {
         /// <summary>Gets or sets the exception, that was raised.</summary>
         public Exception Exception { get; set; }
-
-        /// <summary>Gets or sets the message that was passed with the error.</summary>
-        public string Message { get; set; }
     }
 }

--- a/WebSocketTextClient/SocketErrorEventArgs.cs
+++ b/WebSocketTextClient/SocketErrorEventArgs.cs
@@ -1,0 +1,14 @@
+﻿namespace WebSockets
+{
+    using System;
+
+    /// <summary>Provides additional data for the <see cref="WebSocketTextClient.ErrorReceived"/> event.</summary>
+    public sealed class SocketErrorEventArgs : EventArgs
+    {
+        /// <summary>Gets or sets the exception, that was raised.</summary>
+        public Exception Exception { get; set; }
+
+        /// <summary>Gets or sets the message that was passed with the error.</summary>
+        public string Message { get; set; }
+    }
+}

--- a/WebSocketTextClient/WebSocketTextClient.cs
+++ b/WebSocketTextClient/WebSocketTextClient.cs
@@ -64,15 +64,7 @@
             await socket.ConnectAsync(url, cancellationToken);
             recieveTask.Start();
 
-            if (this.Opened != null)
-            {
-                await Task.Factory.FromAsync(
-                    this.Opened.BeginInvoke,
-                    this.Opened.EndInvoke,
-                    this,
-                    EventArgs.Empty,
-                    null);
-            }
+            this.Opened?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>Adds custom request headers to the initial request.</summary>
@@ -126,28 +118,12 @@
 
                     var responce = Encoding.UTF8.GetString(buffer, 0, writeSegment.Offset);
 
-                    if (this.MessageReceived != null)
-                    {
-                        await Task.Factory.FromAsync(
-                            this.MessageReceived.BeginInvoke,
-                            this.MessageReceived.EndInvoke,
-                            this,
-                            new MessageReceivedEventArgs { Message = responce },
-                            null);
-                    }
+                    this.MessageReceived?.Invoke(this, new MessageReceivedEventArgs { Message = responce });
                 }
             }
             catch (Exception ex)
             {
-                if (this.ErrorReceived != null)
-                {
-                    await Task.Factory.FromAsync(
-                        this.ErrorReceived.BeginInvoke,
-                        this.ErrorReceived.EndInvoke,
-                        this,
-                        new SocketErrorEventArgs { Exception = ex, Message = string.Empty },
-                        null);
-                }
+                this.ErrorReceived?.Invoke(this, new SocketErrorEventArgs { Exception = ex, Message = string.Empty });
             }
         }
 

--- a/WebSocketTextClient/WebSocketTextClient.cs
+++ b/WebSocketTextClient/WebSocketTextClient.cs
@@ -35,10 +35,10 @@ namespace WebSockets
         public event EventHandler<SocketErrorEventArgs> ErrorReceived;
 
         /// <summary>Signals that the websocket was closed.</summary>
-        public event EventHandler SocketClosed;
+        public event EventHandler Closed;
 
         /// <summary>Signals that the socket has opened a connection.</summary>
-        public event EventHandler SocketOpened;
+        public event EventHandler Opened;
 
         /// <summary>
         /// Asynchronously connects to WebSocket server and start receiving income messages in separate Task
@@ -97,8 +97,8 @@ namespace WebSockets
                     var responce = Encoding.UTF8.GetString(buffer, 0, writeSegment.Offset);
 
                     await Task.Factory.FromAsync(
-                        this.MessageReceived.BeginInvoke,
-                        this.MessageReceived.EndInvoke,
+                        this.SocketMessageReceived.BeginInvoke,
+                        this.SocketMessageReceived.EndInvoke,
                         this,
                         new SocketMessageEventArgs { Message = responce },
                         null);

--- a/WebSocketTextClient/WebSocketTextClient.cs
+++ b/WebSocketTextClient/WebSocketTextClient.cs
@@ -48,7 +48,7 @@
         /// <summary>Signals that response message fully received and ready to process.</summary>
         public event EventHandler<MessageReceivedEventArgs> MessageReceived;
 
-        /// <summary>Singals that the websocket received an error.</summary>
+        /// <summary>Signals that the websocket received an error.</summary>
         public event EventHandler<SocketErrorEventArgs> ErrorReceived;
 
         /// <summary>Signals that the websocket was closed.</summary>
@@ -123,7 +123,7 @@
             }
             catch (Exception ex)
             {
-                this.ErrorReceived?.Invoke(this, new SocketErrorEventArgs { Exception = ex, Message = string.Empty });
+                this.ErrorReceived?.Invoke(this, new SocketErrorEventArgs { Exception = ex, Message = "An error occoured." });
             }
         }
 

--- a/WebSocketTextClient/WebSocketTextClient.cs
+++ b/WebSocketTextClient/WebSocketTextClient.cs
@@ -17,28 +17,32 @@
         private readonly int initialRecieveBufferSize;
         private readonly bool autoIncreaseRecieveBuffer;
 
-        /// <summary>Create new instance of WebSocketTextClient.</summary>
-        /// <param name="cancellationToken">Cancels pending send and receive operations</param>
-        /// <param name="initialRecieveBufferSize">Socket initial receive buffer size in bytes</param>
-        /// <param name="autoIncreaseRecieveBuffer">
-        /// If true, receive buffer size will be doubled on overflow. 
-        /// If false, unobserved InvalidOperationException will be thrown on overflow
-        /// </param>
-        public WebSocketTextClient(CancellationToken? cancellationToken = null, int initialRecieveBufferSize = 1024, bool autoIncreaseRecieveBuffer = true)
+        /// <summary>Initializes a new instance of the <see cref="WebSocketTextClient"/> class.</summary>
+        /// <param name="initialRecieveBufferSize">The initial buffer size for incoming messages in bytes.</param>
+        /// <param name="autoIncreaseRecieveBuffer">True to double the buffer on overflow. Otherwise an <see cref="InvalidOperationException"/> will be thrown.</param>
+        public WebSocketTextClient(int initialRecieveBufferSize = 1024, bool autoIncreaseRecieveBuffer = true)
+            : this(CancellationToken.None, initialRecieveBufferSize, autoIncreaseRecieveBuffer)
         {
-            socket = new ClientWebSocket();
-            this.cancellationToken = cancellationToken ?? CancellationToken.None;
-            
+        }
 
-            recieveTask = new Task(RecieveLoop, this.cancellationToken);
-
+        /// <summary>Initializes a new instance of the <see cref="WebSocketTextClient"/> class.</summary>
+        /// <param name="cancellationToken">Cancels pending send and receive operations</param>
+        /// <param name="initialRecieveBufferSize">The initial buffer size for incoming messages in bytes.</param>
+        /// <param name="autoIncreaseRecieveBuffer">True to double the buffer on overflow. Otherwise an <see cref="InvalidOperationException"/> will be thrown.</param>
+        public WebSocketTextClient(CancellationToken cancellationToken, int initialRecieveBufferSize = 1024, bool autoIncreaseRecieveBuffer = true)
+        {
             if (initialRecieveBufferSize <= 0)
             {
                 throw new ArgumentException("Receive buffer size should be greater than zero", nameof(initialRecieveBufferSize));
             }
 
+            this.cancellationToken = cancellationToken;
+            
             this.initialRecieveBufferSize = initialRecieveBufferSize;
             this.autoIncreaseRecieveBuffer = autoIncreaseRecieveBuffer;
+
+            socket = new ClientWebSocket();
+            recieveTask = new Task(RecieveLoop, this.cancellationToken);
         }
 
         /// <summary>Signals that response message fully received and ready to process.</summary>

--- a/WebSocketTextClient/WebSocketTextClient.cs
+++ b/WebSocketTextClient/WebSocketTextClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
@@ -54,6 +55,16 @@ namespace WebSockets
                 this,
                 EventArgs.Empty,
                 null);    
+        }
+
+        /// <summary>Adds custom request headers to the initial request.</summary>
+        /// <param name="headers">A list of custom request headers.</param>
+        public void AddHeaders(params KeyValuePair<string, string>[] headers)
+        {
+            foreach (var header in headers)
+            {
+                this.Socket.Options.SetRequestHeader(header.Key, header.Value);
+            }
         }
 
         /// <summary>

--- a/WebSocketTextClient/WebSocketTextClient.cs
+++ b/WebSocketTextClient/WebSocketTextClient.cs
@@ -37,8 +37,8 @@
             }
 
             var internalTokenSource = new CancellationTokenSource();
-            this.tokenSource = cancellationToken != CancellationToken.None 
-                ? CancellationTokenSource.CreateLinkedTokenSource(internalTokenSource.Token, cancellationToken) 
+            this.tokenSource = cancellationToken != CancellationToken.None
+                ? CancellationTokenSource.CreateLinkedTokenSource(internalTokenSource.Token, cancellationToken)
                 : internalTokenSource;
 
             // Register the disconnect method as a fire and forget method to run when the user requests cancellation
@@ -145,7 +145,7 @@
             }
             catch (Exception ex)
             {
-                this.ErrorReceived?.Invoke(this, new SocketErrorEventArgs { Exception = ex, Message = "An error occoured"});
+                this.ErrorReceived?.Invoke(this, new SocketErrorEventArgs { Exception = ex });
             }
         }
 


### PR DESCRIPTION
This pull request added additional events for errors, open and close. These events and the OnMessage event now use the `EventArgs` or `EventArgs<T>` type to pass along information to the subscriber.
This allows the user to manage multiple socket connections and differentiate by sender.

I also changed all event handler invocations (except `Close`) to be asynchronous, which was done with the `Task.Factory.FromAsync()` method.

Last I added a method to allow the user to add his own headers to the initial socket request. This allows greater flexibility with things such as authorization,